### PR TITLE
Fix DB type service parameter

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -131,7 +131,9 @@ class SysbenchOperator(ops.CharmBase):
         if not (options := self.database.get_execution_options()):
             # Nothing to do, we can abandon this event and wait for the next changes
             return
-        svc.render_service_file(self.database.script(), options, labels=self.labels)
+        svc.render_service_file(
+            self.database.script(), self.database.chosen_db_type(), options, labels=self.labels
+        )
         svc.run()
 
     def _on_relation_broken(self, _):
@@ -264,7 +266,9 @@ class SysbenchOperator(ops.CharmBase):
         if not (options := self.database.get_execution_options()):
             event.fail("Failed: missing database options")
             return
-        svc.render_service_file(self.database.script(), options, labels=self.labels)
+        svc.render_service_file(
+            self.database.script(), self.database.chosen_db_type(), options, labels=self.labels
+        )
         svc.run()
         self.sysbench_status.set(SysbenchExecStatusEnum.RUNNING)
         event.set_results({"status": "running"})

--- a/src/sysbench.py
+++ b/src/sysbench.py
@@ -58,14 +58,14 @@ class SysbenchService:
         return f"/etc/systemd/system/{self.svc}.service"
 
     def render_service_file(
-        self, script: str, db: SysbenchExecutionModel, labels: Optional[str] = ""
+        self, script: str, db_type: str, db: SysbenchExecutionModel, labels: Optional[str] = ""
     ) -> bool:
         """Render the systemd service file."""
         _render(
             "sysbench.service.j2",
             self.svc_path,
             {
-                "db_driver": "mysql",
+                "db_driver": db_type,
                 "threads": db.threads,
                 "tables": db.db_info.tables,
                 "scale": db.db_info.scale,


### PR DESCRIPTION
## Issue

`mysql` DB type was hard-coded inside sysbench service file.

## Solution

get DB type from `database.chosen_db_type` method