### PR TITLE
[DPE-3833] Report error correctly

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -123,18 +123,20 @@ class SysbenchOperator(ops.CharmBase):
 
     def _on_config_changed(self, _):
         # For now, ignore the configuration
+        svc_was_running = False
         svc = SysbenchService()
-        if not svc.is_running():
+        if svc.is_running():
             # Nothing to do, there was no setup yet
-            return
-        svc.stop()
+            svc_was_running = True
+            svc.stop()
         if not (options := self.database.get_execution_options()):
             # Nothing to do, we can abandon this event and wait for the next changes
             return
         svc.render_service_file(
             self.database.script(), self.database.chosen_db_type(), options, labels=self.labels
         )
-        svc.run()
+        if svc_was_running:
+            svc.run()
 
     def _on_relation_broken(self, _):
         SysbenchService().stop()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import re
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,6 +12,7 @@ from types import SimpleNamespace
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
+from tenacity import Retrying, stop_after_delay, wait_fixed
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +98,7 @@ async def test_build_and_deploy(ops_test: OpsTest, db_driver, use_router) -> Non
         "threads": 1,
         "tables": 1,
         "scale": 1,
-        "duration": 10,
+        "duration": 0,
     }
 
     await asyncio.gather(
@@ -159,15 +161,87 @@ async def test_prepare_action(ops_test: OpsTest, db_driver, use_router) -> None:
         raise_on_blocked=True,
         timeout=15 * 60,
     )
-    svc_output = check_service("sysbench_prepared.target")
-    # Looks silly, but we "active" is in "inactive" string :(
-    assert "inactive" not in svc_output and "active" in svc_output
+    for attempt in Retrying(stop=stop_after_delay(40), wait=wait_fixed(10)):
+        with attempt:
+            svc_output = check_service("sysbench_prepared.target")
+            # Looks silly, but we "active" is in "inactive" string :(
+            assert "inactive" not in svc_output and "active" in svc_output
+
+
+@pytest.mark.parametrize(
+    "db_driver",
+    [
+        (pytest.param("mysql", marks=pytest.mark.group("mysql"))),
+        (pytest.param("postgresql", marks=pytest.mark.group("postgresql"))),
+    ],
+)
+@pytest.mark.abort_on_fail
+async def test_run_action_and_cause_failure(ops_test: OpsTest, db_driver) -> None:
+    """Starts a run and then kills the sysbench process. Systemd must then report it as failed."""
+    app = ops_test.model.applications[APP_NAME]
+    await app.set_config({"duration": "0"})
+
+    output = await run_action(ops_test, "run", f"{APP_NAME}/0")
+    assert output.status == "completed"
+
+    svc = "sysbench.service"
+
+    # Make sure we are currently running
+    assert "inactive" not in check_service(svc)
+    # Now, figure out sysbench's PID itself
+    # The check_output is getting strange chars in the output as we, filter it out
+    sysbench_svc_pid = re.findall(
+        r"MainPID=[0-9.]+",
+        subprocess.check_output(
+            f"juju ssh {APP_NAME}/0 -- systemctl show --property=MainPID {svc}",
+            text=True,
+            shell=True,
+        ),
+    )[0].split("MainPID=")[1]
+    pid = (
+        subprocess.check_output(
+            [
+                "juju",
+                "ssh",
+                f"{APP_NAME}/0",
+                "--",
+                "sudo",
+                "cat",
+                f"/proc/{sysbench_svc_pid}/task/{sysbench_svc_pid}/children",
+            ],
+            text=True,
+        )
+        .split("\n")[0]
+        .split(" ")[0]
+    )
+    # Now, kill the sysbench process
+    subprocess.check_output(["juju", "ssh", f"{APP_NAME}/0", "--", "sudo", "kill", "-9", str(pid)])
+
+    # Finally, check if the service is now in a failed state in systemd
+    try:
+        subprocess.check_output(
+            ["juju", "ssh", f"{APP_NAME}/0", "--", "sudo", "systemctl", "is-failed", svc]
+        )
+    except subprocess.CalledProcessError as e:
+        # We expect "is-failed" to succeed, i.e. we have a failed service
+        raise AssertionError(f"Service {svc} is not in a failed state") from e
+
+    async with ops_test.fast_forward("60s"):
+        # Check if the charm is now blocked:
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME],
+            status="blocked",
+            timeout=15 * 60,
+        )
 
 
 @pytest.mark.parametrize("db_driver,use_router", DEPLOY_ALL_GROUP_MARKS)
 @pytest.mark.abort_on_fail
 async def test_run_action(ops_test: OpsTest, db_driver, use_router) -> None:
     """Try to run the benchmark for DURATION and then wait until it is finished."""
+    app = ops_test.model.applications[APP_NAME]
+    await app.set_config({"duration": f"{DURATION}"})
+
     output = await run_action(ops_test, "run", f"{APP_NAME}/0")
     assert output.status == "completed"
 
@@ -176,6 +250,14 @@ async def test_run_action(ops_test: OpsTest, db_driver, use_router) -> None:
     assert "inactive" not in svc_output and "active" in svc_output
     # Wait until it is finished, and retry
     await asyncio.sleep(3 * DURATION)
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        raise_on_blocked=True,
+        timeout=15 * 60,
+    )
+
     try:
         svc_output = check_service("sysbench.service")
     except subprocess.CalledProcessError:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -168,15 +168,9 @@ async def test_prepare_action(ops_test: OpsTest, db_driver, use_router) -> None:
             assert "inactive" not in svc_output and "active" in svc_output
 
 
-@pytest.mark.parametrize(
-    "db_driver",
-    [
-        (pytest.param("mysql", marks=pytest.mark.group("mysql"))),
-        (pytest.param("postgresql", marks=pytest.mark.group("postgresql"))),
-    ],
-)
+@pytest.mark.parametrize("db_driver,use_router", DEPLOY_ALL_GROUP_MARKS)
 @pytest.mark.abort_on_fail
-async def test_run_action_and_cause_failure(ops_test: OpsTest, db_driver) -> None:
+async def test_run_action_and_cause_failure(ops_test: OpsTest, db_driver, use_router) -> None:
     """Starts a run and then kills the sysbench process. Systemd must then report it as failed."""
     app = ops_test.model.applications[APP_NAME]
     await app.set_config({"duration": "0"})


### PR DESCRIPTION
Currently, the `sysbench_svc.py` is silently capturing the sysbench output and not checking if we have a failure or not. This PR extends sysbench_svc to capture the output of the sysbench child and its stdout / stderr.

Closes: #12 