### PR TITLE
[DPE-4070][test] Make microk8s install optional

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,6 +10,8 @@ import pytest_operator.plugin
 import yaml
 from tenacity import Retrying, stop_after_delay, wait_fixed
 
+from .helpers import MICROK8S_CLOUD_NAME
+
 
 @pytest.fixture(scope="module")
 async def microk8s(ops_test: pytest_operator.plugin.OpsTest) -> None:
@@ -46,7 +48,8 @@ async def microk8s(ops_test: pytest_operator.plugin.OpsTest) -> None:
 
             # Add microk8s to the kubeconfig
             subprocess.run(
-                ["juju", "add-k8s", "cloudk8s", "--client", "--controller", ctlname], check=True
+                ["juju", "add-k8s", MICROK8S_CLOUD_NAME, "--client", "--controller", ctlname],
+                check=True,
             )
 
         except subprocess.CalledProcessError as e:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,6 +10,7 @@ MYSQL_APP_NAME = "mysql"
 PGSQL_APP_NAME = "postgresql"
 DURATION = 10
 K8S_DB_MODEL_NAME = "database-" + str(uuid.uuid4())[0:5]
+MICROK8S_CLOUD_NAME = "cloudk8s"
 
 
 DB_CHARM = {

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,6 +23,7 @@ from .helpers import (
     DEPLOY_VM_ONLY_GROUP_MARKS,
     DURATION,
     K8S_DB_MODEL_NAME,
+    MICROK8S_CLOUD_NAME,
 )
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ async def destroy_model_in_k8s(ops_test):
     subprocess.run(["sudo", "snap", "remove", "--purge", "microk8s"], check=True)
     subprocess.run(["sudo", "snap", "remove", "--purge", "kubectl"], check=True)
     subprocess.run(
-        ["juju", "remove-cloud", "--client", "--controller", ctlname, microk8s.cloud_name],
+        ["juju", "remove-cloud", "--client", "--controller", ctlname, MICROK8S_CLOUD_NAME],
         check=True,
     )
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -57,7 +57,7 @@ async def run_action(
 
 
 @pytest.fixture(scope="module", autouse=True)
-async def destroy_model_in_k8s(ops_test, microk8s):
+async def destroy_model_in_k8s(ops_test):
     yield
 
     if ops_test.keep_model:
@@ -66,8 +66,10 @@ async def destroy_model_in_k8s(ops_test, microk8s):
     await controller.connect()
     await controller.destroy_model(K8S_DB_MODEL_NAME)
     await controller.disconnect()
+
     ctlname = list(yaml.safe_load(subprocess.check_output(["juju", "show-controller"])).keys())[0]
 
+    # We have deployed microk8s, and we do not need it anymore
     subprocess.run(["sudo", "snap", "remove", "--purge", "microk8s"], check=True)
     subprocess.run(["sudo", "snap", "remove", "--purge", "kubectl"], check=True)
     subprocess.run(


### PR DESCRIPTION
Currently, whenever running integration tests, it will install microk8s even if the running test has nothing related to k8s.

To resolve that, this PR removes the fixture and leaves the microk8s as it is not needed.

Closes #25 