### PR TITLE
DPE-4009 Adding docs to charmhub

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ options:
     default: 0
     type: int
     description: |
-      Duration of the test, if set to 0, it does not stop.
+      Duration of the test in seconds. If set to 0, it does not stop.
   request-external-connectivity:
     default: True
     type: boolean

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,17 +1,17 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 name: sysbench
-
-
-title: Sysbench Operator
+display-name: Charmed Sysbench
 
 summary: Generates a load against your workload and collect metrics in Prometheus.
-
-
 description: |
   Run this charm to connect with a mysql deployment and test the performance or generate a load against the cluster.
-
 docs: https://discourse.charmhub.io/t/charmed-sysbench-documentation-home/13945
+source: https://github.com/canonical/sysbench-operator
+issues: https://github.com/canonical/sysbench-operator/issues
+website: https://charmhub.io/sysbench
+maintainers:
+  - Canonical Data Platform <data-platform@lists.launchpad.net>
 
 series:
 - jammy

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,6 +11,8 @@ summary: Generates a load against your workload and collect metrics in Prometheu
 description: |
   Run this charm to connect with a mysql deployment and test the performance or generate a load against the cluster.
 
+docs: https://discourse.charmhub.io/t/charmed-sysbench-documentation-home/13945
+
 series:
 - jammy
 - lunar


### PR DESCRIPTION
This PR adds a [discourse topic](https://discourse.charmhub.io/t/charmed-sysbench-documentation-home/13945) to `metadata.yaml`. This content will render at [charmhub.io/sysbench](https://charmhub.io/sysbench) as the home page.

Additionally clarified the `duration` parameter in `config.yaml`, since it doesn't map directly to the original `--time` flag.

[DPE-4009](https://warthogs.atlassian.net/browse/DPE-4009) 

[DPE-4009]: https://warthogs.atlassian.net/browse/DPE-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ