### PR TITLE
[MISC] Add rustup to charm build

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -15,12 +15,15 @@ parts:
           echo 'ERROR: Use "tox run -e build-dev" instead of calling "charmcraft pack" directly' >&2
           exit 1
       fi
+    override-build: |
+      rustup default stable
+      craftctl default
     charm-strict-dependencies: true
+    build-snaps:
+      - rustup/latest/stable
     prime:
       - scripts
     build-packages:
       - libffi-dev
       - libssl-dev
       - pkg-config
-      - rustc
-      - cargo


### PR DESCRIPTION
rpds-py fails to build on a clean [CI build](https://github.com/canonical/sysbench-operator/actions/runs/10901322459/job/30252131607#step:11:454):
```
::    ::       error: package `triomphe v0.1.13` cannot be built because it requires rustc 1.76 or newer, while the currently active rustc version is 1.75.0
::    ::       Either upgrade to rustc 1.76 or newer, or use
::    ::       cargo update triomphe@0.1.13 --precise ver
```

Adding rust up to get latest stable rustc