### PR TITLE
Add s390x arch

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,6 +5,7 @@ type: charm
 platforms:
   ubuntu@22.04:amd64:
   ubuntu@22.04:arm64:
+  ubuntu@22.04:s390x:
 # Files implicitly created by charmcraft without a part:
 # - dispatch (https://github.com/canonical/charmcraft/pull/1898)
 # - manifest.yaml


### PR DESCRIPTION
https://warthogs.atlassian.net/browse/DPE-7054

There are currently only 3 IS-hosted s390x github runners—not enough to add s390x integration tests