### PR TITLE
Fix for File is not always closed

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1891,7 +1891,8 @@ class ProviderData(Data):
         if not schema_path.exists():
             raise FileNotFoundError(f"Can't locate status schema file: {schema_path}")
 
-        content = json.load(open(schema_path, "r"))
+        with open(schema_path, "r") as schema_file:
+            content = json.load(schema_file)
 
         return {s["code"]: RelationStatus(**s) for s in content.get("statuses", [])}
 


### PR DESCRIPTION
Use a context manager to ensure the schema file is always closed, even if `json.load` raises.

Best fix in this file: in `lib/charms/data_platform_libs/v0/data_interfaces.py`, method `_load_status_schema`, replace the inline `json.load(open(...))` with:

- `with open(schema_path, "r") as schema_file:`
- `content = json.load(schema_file)`

This keeps functionality unchanged while guaranteeing closure on all paths. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._